### PR TITLE
Update Audit test 4_1_3 with correct auditctl time status ordering

### DIFF
--- a/section_4/cis_4.1/cis_4.1.3.yml
+++ b/section_4/cis_4.1/cis_4.1.3.yml
@@ -25,9 +25,9 @@ command:
     exec: auditctl -l | grep time-change
     exit-status: 0
     stdout:
-    - '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change'
+    - '-a always,exit -F arch=b32 -S stime,settimeofday,adjtimex -F key=time-change'
     - '-a always,exit -F arch=b32 -S clock_settime -F key=time-change'
-    - '-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change'
+    - '-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=time-change'
     - '-a always,exit -F arch=b64 -S clock_settime -F key=time-change'
     - '-w /etc/localtime -p wa -k time-change'
     meta:


### PR DESCRIPTION
**Overall Review of Changes:**
This is to correct the output from the auditctl command for how Amazon Linux 2 displays the values stored in the rules file

https://github.com/ansible-lockdown/AMAZON2-CIS-Audit/blob/devel/section_4/cis_4.1/cis_4.1.3.yml

Although the CIS Benchmark says to run:
`grep time-change /etc/audit/rules.d/*.rules`
`auditctl -l | grep time-change`
and "Verify output of both matches"

The issue is that the output of `auditctl -l` is differing to the written config as it groups the `-S` options together as a comma separated list and also now shows `-k time-change` as `-F key=time-change`
So the "Config" test passes but the "Live" test fails but only because of a display issue, not because the config is incorrect.
So this change is to update the test to better match the actual `auditctl -l` output

**How has this been tested?:**
We have run it against a EC2 instance that has had the Amazon2-CIS repo hardening steps completed.