### PR TITLE
Allow specifying a list of unconfined services to ignore/accept

### DIFF
--- a/section_1/cis_1.6/cis_1.6.1_6.yml
+++ b/section_1/cis_1.6/cis_1.6.1_6.yml
@@ -107,7 +107,7 @@ command:
   selinux_unconfined:
     title: 1.6.1.6 | Ensure no unconfined services exist
     exit-status: 1
-    exec: "ps -eZ | grep unconfined_service_t"
+    exec: "ps -eZ | grep unconfined_service_t{{ if .Vars.amazon2cis_unconfined_services }} | grep -v{{ range .Vars.amazon2cis_unconfined_services }} -e {{ . }}{{ end }}{{ end }}"
     stdout: ['!/./']
     meta:
       server: 1

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -315,6 +315,9 @@ amazon2cis_aide_cron:
 amazon2cis_bootloader_password: grub.pbkdf2.sha512.changethispart
 amazon2cis_set_boot_pass: false
 
+# 1.6.1.6 List of unconfined services to accept (e.g. - amazon-ssm-agen)
+amazon2cis_unconfined_services: []
+
 # Warning Banner Content (issue, issue.net, motd)
 amazon2cis_warning_banner: Authorized uses only. All activity may be monitored and reported.
 # End Banner


### PR DESCRIPTION
Hello! We've made the adjustment below on our own side, but contributing it back if you want it! Feel free to reject/close if not.

In the CIS Benchmark, for "**1.6.1.6 Ensure no unconfined services exist**" it states:

> Note: Occasionally certain daemons such as backup or centralized management software may require running unconfined. Any such software should be carefully analyzed and documented before such an exception is made.

We have a use case where we have a couple of services that must run unconfined.
(e.g. amazon-ssm-agent requires root access to perform some functions and although the [amazon-ssm-agent-selinux](https://github.com/aws/amazon-ssm-agent-selinux) policy exists, it removes root access).
**However, we still want this test to run and ensure no other services are unconfined.**

This change adds a new variable `amazon2cis_unconfined_services` which allows specifying a list of service names to ignore/accept while still alerting if other service names appear unconfined.

This is done by appending the existing command with a inverted grep (`grep -v`) and using the -e option to append multiple items to remove from the listing.
So for example, if you set:
```yaml
amazon2cis_unconfined_services:
- amazon-ssm-agen
- ssm-agent-worke
- ssm-document-wo
```
The command run would be:
```shell
ps -eZ | grep unconfined_service_t | grep -v -e amazon-ssm-agen -e ssm-agent-worke -e ssm-document-wo
```

When the `amazon2cis_unconfined_services` variable is left as the default empty list, then the command is run as current existing behaviour:
```shell
ps -eZ | grep unconfined_service_t
```

NOTE: The names listed, e.g. `amazon-ssm-agen` with the missing `t` are not typos, the service name must be provided as it appears in the output of `ps -eZ | grep unconfined_service_t` and it appears the names get truncated at 15 characters.

