### PR TITLE
issue #43 remediation addressed thanks to @gocyclones

### DIFF
--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -429,13 +429,6 @@ amazon2cis_rule_6_2_8: true
 amazon2cis_rule_6_2_9: true
 amazon2cis_rule_6_2_10: true
 amazon2cis_rule_6_2_11: true
-amazon2cis_rule_6_2_12: true
-amazon2cis_rule_6_2_13: true
-amazon2cis_rule_6_2_14: true
-amazon2cis_rule_6_2_15: true
-amazon2cis_rule_6_2_16: true
-amazon2cis_rule_6_2_17: true
-
 
 ####
 ## Section 1


### PR DESCRIPTION
**Overall Review of Changes:**
removed legacy references to 6.2.2- 6.2.17 as they shouldn't exist 

**Issue Fixes:**
[#48](https://github.com/ansible-lockdown/AMAZON2-CIS/pull/48)


**How has this been tested?:**
No data to go with it it

